### PR TITLE
✨ feat: Create a reusable VPC module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Terraform files
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.*
+crash.log
+
+# Local .terraform directories
+**/.terraform/*
+
+# Ignore macOS system files
+.DS_Store
+
+# .env for environment variables
+.env
+
+# Ignore IDE specific files
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
-# terraform-modules-practice
+# Terraform Modularization Pracitce
+
+> 간단한 연습 과정에서 참고했던 자료는 `code`와 `./modules/vpc/README.md`에 기재하였습니다.
+
+</br>
+
+프로젝트는 아래와 같은 구조를 가지고 있습니다.
+
+```
+infrastructure
+├── global
+│   └── s3
+│       ├── backend.tf
+│       ├── main.tf
+│       └── outputs.tf
+│
+├── dev
+│   ├── service
+│   │   ├── backend.tf
+│   │   ├── main.tf
+│   │   └── outputs.tf
+│   │
+│   └── vpc
+│       ├── backend.tf
+│       ├── main.tf
+│       └── outputs.tf
+│
+└── modules
+    └── vpc
+        ├── main.tf
+        ├── outputs.tf
+        └── vars.tf
+```
+
+- global
+  - 일반적으로 여러 환경(dev, staging, prod)에 걸쳐 공통으로 사용되는 AWS 리소스를 정의하는 테라폼 코드를 담고 있습니다.
+
+- dev
+  - dev 환경의 리소스를 정의한 공간입니다.
+
+- modules
+  - 여러 Terraform 구성 간에 재사용 가능한 code block이 위치하는 공간입니다.
+
+</br>
+
+각 하위 디렉토리들은 다음과 같은 파일 구성을 가지고 있습니다. 
+
+```
+└── services
+    └── backend
+        ├── backend.tf
+        ├── main.tf
+        ├── outputs.tf
+        └── vars.tf
+```
+
+- backend.tf
+  - terraform의 state를 관리 및 공유하는 백엔드 설정을 정의하는 파일입니다.
+  - 각 디렉토리가 독립된 Terraform 실행 단위이기 떄문에, 이러한 디렉토리마다 독립된 state file이 생성되고 관리되어야 합니다.
+  - 그래서 Terraform 상태를 저장하고 관리하기 위해 AWS S3 버킷을 활용합니다. 이는 Terraform이 관리하는 인프라의 상태를 안전하게 유지하고, 여러 개발자가 인프라를 관리할 때의 문제를 방지하는데 도움이 됩니다.
+
+- main.tf
+  - Terraform 설정 코드 파일입니다.
+
+- outputs.tf
+  - 해당 디렉토리가 Terraform에 의해 실행된 후 생성될 output들을 정의해놓은 파일입니다.
+
+- vars.tf
+  - variable들을 지정해 놓은 파일입니다.
+

--- a/dev/service/.terraform.lock.hcl
+++ b/dev/service/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.8.0"
+  hashes = [
+    "h1:vnjWfeuf4AflWsRq3ivVig8dR8PAg8BHTVyAtOzJ1yQ=",
+    "zh:0974311d5e1becfdcbdae43d022d52689fdad32a4145659e56ac534bcb8cba02",
+    "zh:100dc64a90fc0d36cf6e2882b4358fde17705edd8ab3c5f2c06d219c36b21565",
+    "zh:467a86de8a7d77cde5c3386f9e82d7f1bf5972d1b3d177e797d1d9d2e87fd357",
+    "zh:4ad1f8ef5c5522f81d271b93594a43a7666b3409ca201a1911cd950e489ef12b",
+    "zh:540a50ab7061c6df2057ec9580890a9e86a687233120af738985fa84dde2a20a",
+    "zh:6e7b73b770e92891da94751c3e0cff1e1b852f5121da8c4a689056833eeb7d94",
+    "zh:879d42721e86331b05ff77bd219ca9a062485cdb2fa803d2dcf63084f25d484c",
+    "zh:980563e615fbba127c02df6dc8872ce60f7137df45fdb8cd801cdcbae6cf192a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6ad25c4d3edde466ea68731097aedad4b68278af0742fc1ab71d2c30491f92e",
+    "zh:af8df9e06f576c11ce67ac2b675d0d8db4aac618fec95d27c10aa59436feebbf",
+    "zh:b625ca7c4b99c6b3af34041b9773ccd9d80b0dde264c40b5d163a6abd73793af",
+    "zh:c9e0ca6aa48ebaa0892ac438392c49052a86605f490950d5317855f35ab7d74a",
+    "zh:dc500a03d3ed6b1fed3f118a55a7fb93bf172965ae6b2f25cc7f4a152e44edd7",
+    "zh:e0438bf67d93a29f0d56f9a4544297155ca85c0f10626778d4c3aa68c7e93581",
+  ]
+}

--- a/dev/service/backend.tf
+++ b/dev/service/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "dev-tf-state"
+    key     = "dev/ec2.state"
+    region  = "ap-northeast-2"
+    profile = "jongbeom"
+  }
+}

--- a/dev/service/main.tf
+++ b/dev/service/main.tf
@@ -1,0 +1,90 @@
+provider "aws" {
+  region  = "ap-northeast-2"
+  profile = "jongbeom"
+}
+
+###########################################################
+## Remote States
+###########################################################
+data "terraform_remote_state" "vpc" {
+  backend = "s3"
+
+  config = {
+    bucket  = "dev-tf-state"
+    key     = "dev/vpc.state"
+    region  = "ap-northeast-2"
+    profile = "jongbeom"
+  }
+}
+
+###########################################################
+## EC2 Instance
+###########################################################
+resource "aws_instance" "ec2" {
+  count         = length(data.terraform_remote_state.vpc.outputs.public_subnet_az_to_id_map)
+  ami           = "ami-0c0ea4662d3cca101" # https://cloud-images.ubuntu.com/locator/ec2/
+  instance_type = "t3.micro"
+  subnet_id     = data.terraform_remote_state.vpc.outputs.public_subnet_ids[count.index]
+
+  tags = {
+    Name = "EC2-${count.index}"
+  }
+}
+
+###########################################################
+## EIP
+###########################################################
+resource "aws_eip" "eip" {
+  count      = length(aws_instance.ec2)
+  instance   = aws_instance.ec2[count.index].id
+  domain     = "vpc"
+}
+
+###########################################################
+## Security Groups
+###########################################################
+resource "aws_security_group" "dev_ec2" {
+  vpc_id      = data.terraform_remote_state.vpc.outputs.vpc_id
+  name        = "EC2"
+  description = "EC2 Security Group"
+}
+
+resource "aws_security_group_rule" "ssh_ingress" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  security_group_id = aws_security_group.dev_ec2.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "http_ingress" {
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  security_group_id = aws_security_group.dev_ec2.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "https_ingress" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.dev_ec2.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "all_traffic_egress" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "-1"
+  security_group_id = aws_security_group.dev_ec2.id
+  cidr_blocks       = ["0.0.0.0/0"]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/dev/service/outputs.tf
+++ b/dev/service/outputs.tf
@@ -1,0 +1,11 @@
+output "instance_ids" {
+  value = [ for instance in aws_instance.ec2: instance.id ]
+}
+
+output "instance_public_ips" {
+  value = [ for eip in aws_eip.eip : eip.public_id ]
+}
+
+output "security_group_id" {
+  value = aws_security_group.dev_ec2.id
+}

--- a/dev/vpc/.terraform.lock.hcl
+++ b/dev/vpc/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.8.0"
+  hashes = [
+    "h1:vnjWfeuf4AflWsRq3ivVig8dR8PAg8BHTVyAtOzJ1yQ=",
+    "zh:0974311d5e1becfdcbdae43d022d52689fdad32a4145659e56ac534bcb8cba02",
+    "zh:100dc64a90fc0d36cf6e2882b4358fde17705edd8ab3c5f2c06d219c36b21565",
+    "zh:467a86de8a7d77cde5c3386f9e82d7f1bf5972d1b3d177e797d1d9d2e87fd357",
+    "zh:4ad1f8ef5c5522f81d271b93594a43a7666b3409ca201a1911cd950e489ef12b",
+    "zh:540a50ab7061c6df2057ec9580890a9e86a687233120af738985fa84dde2a20a",
+    "zh:6e7b73b770e92891da94751c3e0cff1e1b852f5121da8c4a689056833eeb7d94",
+    "zh:879d42721e86331b05ff77bd219ca9a062485cdb2fa803d2dcf63084f25d484c",
+    "zh:980563e615fbba127c02df6dc8872ce60f7137df45fdb8cd801cdcbae6cf192a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6ad25c4d3edde466ea68731097aedad4b68278af0742fc1ab71d2c30491f92e",
+    "zh:af8df9e06f576c11ce67ac2b675d0d8db4aac618fec95d27c10aa59436feebbf",
+    "zh:b625ca7c4b99c6b3af34041b9773ccd9d80b0dde264c40b5d163a6abd73793af",
+    "zh:c9e0ca6aa48ebaa0892ac438392c49052a86605f490950d5317855f35ab7d74a",
+    "zh:dc500a03d3ed6b1fed3f118a55a7fb93bf172965ae6b2f25cc7f4a152e44edd7",
+    "zh:e0438bf67d93a29f0d56f9a4544297155ca85c0f10626778d4c3aa68c7e93581",
+  ]
+}

--- a/dev/vpc/backend.tf
+++ b/dev/vpc/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "dev-tf-state"
+    key     = "dev/vpc.state"
+    region  = "ap-northeast-2"
+    profile = "jongbeom"
+  }
+}

--- a/dev/vpc/main.tf
+++ b/dev/vpc/main.tf
@@ -1,0 +1,30 @@
+provider "aws" {
+  region  = "ap-northeast-2"
+  profile = "jongbeom"
+}
+
+############################################################
+# VPC
+############################################################
+module "vpc" {
+  source         = "../../modules/vpc"
+  cidr_block     = "172.5.0.0/16"
+  name           = "Dev"
+  public_subnets = [
+    {
+      cidr_block = "172.5.0.0/24"
+      zone       = "ap-northeast-2a"
+      tags       = { Name = "Dev Public Subnet 1" }
+    },
+    {
+      cidr_block = "172.5.2.0/24"
+      zone       = "ap-northeast-2b"
+      tags       = { Name = "Dev Public Subnet 2" }
+    },
+    {
+      cidr_block = "172.5.4.0/24"
+      zone       = "ap-northeast-2c"
+      tags       = { Name = "Dev Public Subnet 3" }
+    },
+  ]
+}

--- a/dev/vpc/outputs.tf
+++ b/dev/vpc/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" { 
+  value = module.vpc.vpc_id
+}
+
+output "ap-northeast-2a_public_subnet_id" {
+  value = module.vpc.public_subnet_az_to_id_map["ap-northeast-2a"]
+}
+
+output "ap-northeast-2b_public_subnet_id" {
+  value = module.vpc.public_subnet_az_to_id_map["ap-northeast-2b"]
+}
+
+output "ap-northeast-2c_public_subnet_id" {
+  value = module.vpc.public_subnet_az_to_id_map["ap-northeast-2c"]
+}
+
+output "public_subnet_ids" {
+  value = module.vpc.public_subnet_ids
+}

--- a/global/s3/.terraform.lock.hcl
+++ b/global/s3/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.8.0"
+  hashes = [
+    "h1:vnjWfeuf4AflWsRq3ivVig8dR8PAg8BHTVyAtOzJ1yQ=",
+    "zh:0974311d5e1becfdcbdae43d022d52689fdad32a4145659e56ac534bcb8cba02",
+    "zh:100dc64a90fc0d36cf6e2882b4358fde17705edd8ab3c5f2c06d219c36b21565",
+    "zh:467a86de8a7d77cde5c3386f9e82d7f1bf5972d1b3d177e797d1d9d2e87fd357",
+    "zh:4ad1f8ef5c5522f81d271b93594a43a7666b3409ca201a1911cd950e489ef12b",
+    "zh:540a50ab7061c6df2057ec9580890a9e86a687233120af738985fa84dde2a20a",
+    "zh:6e7b73b770e92891da94751c3e0cff1e1b852f5121da8c4a689056833eeb7d94",
+    "zh:879d42721e86331b05ff77bd219ca9a062485cdb2fa803d2dcf63084f25d484c",
+    "zh:980563e615fbba127c02df6dc8872ce60f7137df45fdb8cd801cdcbae6cf192a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6ad25c4d3edde466ea68731097aedad4b68278af0742fc1ab71d2c30491f92e",
+    "zh:af8df9e06f576c11ce67ac2b675d0d8db4aac618fec95d27c10aa59436feebbf",
+    "zh:b625ca7c4b99c6b3af34041b9773ccd9d80b0dde264c40b5d163a6abd73793af",
+    "zh:c9e0ca6aa48ebaa0892ac438392c49052a86605f490950d5317855f35ab7d74a",
+    "zh:dc500a03d3ed6b1fed3f118a55a7fb93bf172965ae6b2f25cc7f4a152e44edd7",
+    "zh:e0438bf67d93a29f0d56f9a4544297155ca85c0f10626778d4c3aa68c7e93581",
+  ]
+}

--- a/global/s3/backend.tf
+++ b/global/s3/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "dev-tf-state"
+    key     = "global/s3/terraform.state"
+    region  = "ap-northeast-2"
+    profile = "jongbeom"
+  }
+}

--- a/global/s3/main.tf
+++ b/global/s3/main.tf
@@ -1,0 +1,20 @@
+provider "aws" {
+  region  = "ap-northeast-2"
+  profile = "jongbeom"
+}
+
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = "dev-tf-state"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state_versioning" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -1,0 +1,72 @@
+# VPC
+
+현재 최소한의 recources만을 모듈화하였으며, 이후 추가로 작성하며 update 할 예정입니다.
+
+vpc 모듈화를 진행하며 참고한 자료는 다음과 같습니다.
+
+- https://github.com/terraform-aws-modules/terraform-aws-vpc
+- https://developer.hashicorp.com/terraform/language/meta-arguments/for_each
+
+</br>
+
+Terraform module for VPC. This module creates the following AWS resources:
+
+- VPC
+- Public subnets
+- Routing table for public subnets
+- Internet gateway for public subnets
+
+</br>
+
+## Usage
+--------------------------------------------------------------------------------
+```terraform
+module "vpc" {
+  source     = "../modules/vpc"
+  name       = "your-vpc-name"
+  cidr_block = "10.0.0.0/16"
+
+  public_subnets = [
+    {
+      cidr_block = "10.0.2.0/24"
+      zone       = "ap-northeast-2a"
+      tags       = { Name = "your-public-subnet-name-1" }
+    },
+    {
+      cidr_block = "10.0.4.0/24"
+      zone       = "ap-northeast-2b"
+      tags       = { Name = "your-public-subnet-name-2" }
+    },
+    {
+      cidr_block = "10.0.6.0/24"
+      zone       = "ap-northeast-2c"
+      tags       = { Name = "your-public-subnet-name-3" }
+    }
+  ]
+}
+```
+> 🚧 This code is a basic example. For actual use, you can change this value according to your requirements.
+
+
+</br>
+
+## Variables
+--------------------------------------------------------------------------------
+```terraform
+variable "name"            {    } 
+variable "cidr_block"      {    } 
+variable "public_subnets"  {    } 
+```
+
+</br>
+
+## Outputs
+--------------------------------------------------------------------------------
+- `vpc_id`
+- `vpc_cidr_block`
+- `public_subnet_ids`
+- `public_route_table_id`
+- `public_subnet_az_to_id_map`
+
+
+</br>

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,0 +1,55 @@
+############################################################
+# VPC 
+############################################################
+resource "aws_vpc" "vpc" {
+  cidr_block = var.cidr_block
+
+  tags = { 
+    Name = var.name 
+  }
+}
+
+############################################################
+# Public Subnets
+############################################################
+resource "aws_subnet" "public_subnets" {
+  for_each = { for v in var.public_subnets : v.zone => v }
+
+	vpc_id            = aws_vpc.vpc.id
+	cidr_block        = each.value.cidr_block
+	availability_zone = each.value.zone
+
+  tags  = each.value.tags
+}
+
+############################################################
+# Routing table for public subnets
+############################################################
+resource "aws_internet_gateway" "ig" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = "${var.name} Internet Gateway" 
+  }
+}
+
+resource "aws_default_route_table" "default" {
+  default_route_table_id = aws_vpc.vpc.default_route_table_id
+
+  tags = { 
+    Name = "${var.name} Public Default Route Table" 
+  }
+}
+
+resource "aws_route" "public" {
+	route_table_id         = aws_vpc.vpc.default_route_table_id
+	destination_cidr_block = "0.0.0.0/0"
+	gateway_id             = aws_internet_gateway.ig.id
+}
+
+resource "aws_route_table_association" "public" {
+  for_each = aws_subnet.public_subnets
+
+	subnet_id      = each.value.id
+	route_table_id = aws_vpc.vpc.default_route_table_id
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" { 
+  value = "${aws_vpc.vpc.id}"
+}
+
+output "vpc_cidr_block" {
+  value = "${aws_vpc.vpc.cidr_block}"
+}
+
+output "public_subnet_ids" {
+  value = [ for subnet in aws_subnet.public_subnets: subnet.id ]
+}
+
+output "public_route_table_id" {
+  value =  "${aws_default_route_table.default.id}"
+}
+
+output "public_subnet_az_to_id_map" {
+  value = { for subnet in aws_subnet.public_subnets: subnet.availability_zone => subnet.id }
+}

--- a/modules/vpc/vars.tf
+++ b/modules/vpc/vars.tf
@@ -1,0 +1,10 @@
+variable "name"             { default = "" } 
+variable "cidr_block"       {              } 
+variable "public_subnets"   {
+  type = list(object({
+    cidr_block = string
+    zone       = string
+    tags       = map(any)
+  }))
+  default = []
+}


### PR DESCRIPTION
## 작업배경

Terraform 모듈화는 다음과 같은 이유로 필요합니다.

- 재사용성 
  - 모듈 코드를 한 번 작성하고 여러 프로젝트나 환경에서 재사용 할 수 있습니다.
  - 이는 반복적인 작업을 줄이고, 일관된 인프라를 빠르게 배포할 수 있게 합니다.
- 유지 보수성
  - 버그 수정과 기능 추가가 필요한 경우 모듈화된 코드를 수정함으로써 작업을 용이하게 합니다.
- 가독성
  - 모듈 사용을 쉽고 직관적으로 작성하면, 실제 복잡한 리소스 정의 코드보다 읽기 쉽고 구조를 이해하는데 도움을 줄 수 있습니다.
- 일관성
  - 모듈을 사용하면 여러 환경에서 리소스를 구성할 때, 인프라의 일관성을 보장할 수 있습니다.
- 생산성
  - 인프라 코드 작성 시간을 줄일 수 있으며, 개발자가 다른 작업에 더 집중 할 수 있게 합니다.

</br>

## 작업내용 

- VPC 리소스를 생성하는데 사용되는 모듈을 작성합니다.
  - modularization에 관한 세부 내용을 `./modules/vpc/README.md`에 작성합니다. 
- 해당 모듈을 사용하는 간단한 EC2 인스턴스를 정의합니다.

</br>